### PR TITLE
Fix race condition in download handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -139,8 +139,8 @@ func downloadHandler(w http.ResponseWriter, r *http.Request) {
 	// Check if the file has expired
 	if time.Since(info.CreatedAt) > time.Minute*5 {
 		delete(fileTokens, token)
-		os.Remove(info.Path)
 		mutex.Unlock()
+		os.Remove(info.Path)
 		http.Error(w, "Link is invalid or has expired.", http.StatusNotFound)
 		return
 	}


### PR DESCRIPTION
Previously, a race condition could occur in the download handler if two requests for the same file were received at the same time. This could lead to one of your requests failing, even if the download link was valid.

This commit fixes the race condition by adding a file-specific mutex to the `fileInfo` struct. This ensures that only one download can happen at a time for a given file.